### PR TITLE
refactoring this lp to catch errors, #12

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -147,7 +147,7 @@ function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableTo
 
 function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(n); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
 
 function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter); }
 
@@ -293,6 +293,9 @@ var bulk = (0, _lodashFp.curry)(function (sObject, operation, options, fun, stat
         references: [res].concat(_toConsumableArray(state.references))
       });
     }
+  })["catch"](function (error) {
+    console.log(error);
+    reject(error);
   });
 });
 /**
@@ -321,6 +324,9 @@ var create = (0, _lodashFp.curry)(function (sObject, attrs, state) {
     return _objectSpread({}, state, {
       references: [recordResult].concat(_toConsumableArray(state.references))
     });
+  })["catch"](function (error) {
+    console.log(error);
+    reject(error);
   });
 });
 /**
@@ -359,6 +365,9 @@ var createIf = (0, _lodashFp.curry)(function (logical, sObject, attrs, state) {
       return _objectSpread({}, state, {
         references: [recordResult].concat(_toConsumableArray(state.references))
       });
+    })["catch"](function (error) {
+      console.log(error);
+      reject(error);
     });
   } else {
     return _objectSpread({}, state);
@@ -387,10 +396,13 @@ var upsert = (0, _lodashFp.curry)(function (sObject, externalId, attrs, state) {
   var finalAttrs = expandReferences(state, attrs);
   console.info("Upserting ".concat(sObject, " with externalId"), externalId, ":", finalAttrs);
   return connection.upsert(sObject, finalAttrs, externalId).then(function (recordResult) {
-    console.log('Result : ' + JSON.stringify(recordResult));
+    console.log("Result : " + JSON.stringify(recordResult));
     return _objectSpread({}, state, {
       references: [recordResult].concat(_toConsumableArray(state.references))
     });
+  })["catch"](function (error) {
+    console.log(error);
+    reject(error);
   });
 });
 /**
@@ -430,6 +442,9 @@ var upsertIf = (0, _lodashFp.curry)(function (logical, sObject, externalId, attr
       return _objectSpread({}, state, {
         references: [recordResult].concat(_toConsumableArray(state.references))
       });
+    })["catch"](function (error) {
+      console.log(error);
+      reject(error);
     });
   } else {
     return _objectSpread({}, state);
@@ -461,6 +476,9 @@ var update = (0, _lodashFp.curry)(function (sObject, attrs, state) {
     return _objectSpread({}, state, {
       references: [recordResult].concat(_toConsumableArray(state.references))
     });
+  })["catch"](function (error) {
+    console.log(error);
+    reject(error);
   });
 });
 /**
@@ -528,6 +546,9 @@ function login(state) {
   // })
   .then(function () {
     return state;
+  })["catch"](function (error) {
+    console.log(error);
+    reject(error);
   });
 }
 /**

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -29,13 +29,13 @@ export const describe = curry(function(sObject, state) {
   let {connection} = state;
 
   return connection.sobject(sObject).describe()
-  .then(function(meta) {
+  .then(meta => {
     console.log('Label : ' + meta.label);
     console.log('Num of Fields : ' + meta.fields.length);
 
     return state;
   })
-  .catch(function(err) {
+  .catch(err => {
     console.error(err);
     return err;
   })
@@ -55,13 +55,13 @@ export const describeGlobal = curry(function(sObject, state) {
   let {connection} = state;
 
   return connection.describeGlobal()
-  .then(function(res) {
+  .then(res => {
     console.log('Num of SObjects : ' + res.sobjects.length);
     console.log(JSON.stringify(res.sobjects, null, 2));
 
     return state;
   })
-  .catch(function(err) {
+  .catch(err => {
     console.error(err);
     return err;
   })
@@ -144,7 +144,7 @@ export const bulk = curry(function(sObject, operation, options, fun, state) {
 
     batch.poll(3 * 1000, 120 * 1000);
 
-  }).then((res) => {
+  }).then(res => {
     job.close();
     const errors = res.filter(item => {
       return item.success === false
@@ -160,6 +160,10 @@ export const bulk = curry(function(sObject, operation, options, fun, state) {
       }
     }
   })
+  .catch(error => {
+    console.log(error);
+    reject(error);
+  });
 
 });
 
@@ -183,13 +187,16 @@ export const create = curry(function(sObject, attrs, state) {
   console.info(`Creating ${sObject}`, finalAttrs);
 
   return connection.create(sObject, finalAttrs)
-  .then(function(recordResult) {
+  .then(recordResult => {
     console.log('Result : ' + JSON.stringify(recordResult));
     return {
       ...state, references: [recordResult, ...state.references]
     }
   })
-
+  .catch(error => {
+    console.log(error);
+    reject(error);
+  });
 });
 
 /**
@@ -218,12 +225,16 @@ export const createIf = curry(function(logical, sObject, attrs, state) {
 
   if (logical) {
     return connection.create(sObject, finalAttrs)
-    .then(function(recordResult) {
+    .then(recordResult => {
       console.log('Result : ' + JSON.stringify(recordResult));
       return {
         ...state, references: [recordResult, ...state.references]
       }
     })
+    .catch(error => {
+      console.log(error);
+      reject(error);
+    });
   } else {
     return {
       ...state
@@ -255,13 +266,17 @@ export const upsert = curry(function(sObject, externalId, attrs, state) {
   );
 
   return connection.upsert(sObject, finalAttrs, externalId)
-  .then(function(recordResult) {
-    console.log('Result : ' + JSON.stringify(recordResult));
+  .then(recordResult => {
+    console.log("Result : " + JSON.stringify(recordResult));
     return {
-      ...state, references: [recordResult, ...state.references]
-    }
+      ...state,
+      references: [recordResult, ...state.references],
+    };
   })
-
+  .catch(error => {
+    console.log(error);
+    reject(error);
+  });
 })
 
 /**
@@ -293,12 +308,16 @@ export const upsertIf = curry(function(logical, sObject, externalId, attrs, stat
 
   if (logical) {
     return connection.upsert(sObject, finalAttrs, externalId)
-    .then(function(recordResult) {
+    .then(recordResult => {
       console.log('Result : ' + JSON.stringify(recordResult));
       return {
         ...state, references: [recordResult, ...state.references]
       }
     })
+    .catch(error => {
+      console.log(error);
+      reject(error);
+    });
   } else {
     return {
       ...state
@@ -327,12 +346,16 @@ export const update = curry(function(sObject, attrs, state) {
   console.info(`Updating ${sObject}`, finalAttrs);
 
   return connection.update(sObject, finalAttrs)
-  .then(function(recordResult) {
+  .then(recordResult => {
     console.log('Result : ' + JSON.stringify(recordResult));
     return {
       ...state, references: [recordResult, ...state.references]
     }
   })
+  .catch(error => {
+    console.log(error);
+    reject(error);
+  });
 
 });
 
@@ -391,7 +414,10 @@ function login(state) {
     //   return state;
     // })
     .then(() => state)
-
+    .catch(error => {
+      console.log(error);
+      reject(error);
+    });
 }
 
 /**


### PR DESCRIPTION
@taylordowns2000 this PR is mainly to open the debate on how we should refactor this LP. Eventually, if we agree on something it could lead to refactoring the others in such way.

I added a `catch` to reject errors. Note that some functions such as `describe` and `describeGlobal` were already use the format of `.then(() => {...} .catch(() => {...}` but the others were not.

I tried executing with this format and this is the error obtained (as expected).
![Screenshot from 2020-09-14 18-06-49](https://user-images.githubusercontent.com/8411231/93123297-63152680-f6b7-11ea-98b6-b38659d76e38.png)
