### PR TITLE
Refactor operations to use composeNextState, recursivelyExpandReferences

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -1,11 +1,9 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.toArray = exports.sourceValue = exports.source = exports.referencePath = exports.merge = exports.map = exports.lastReferenceValue = exports.join = exports.index = exports.humanProper = exports.fields = exports.field = exports.each = exports.dataValue = exports.dataPath = exports.combine = exports.beta = exports.arrayToString = exports.alterState = exports.relationship = exports.lookup = exports.reference = exports.update = exports.upsertIf = exports.upsert = exports.createIf = exports.create = exports.bulk = exports.query = exports.retrieve = exports.describe = undefined;
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; /** @module Adaptor */
 
@@ -22,147 +20,146 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 exports.execute = execute;
 exports.steps = steps;
-exports.recursivelyExpandReferences = recursivelyExpandReferences;
 
-var _sourceHelpers = require('./sourceHelpers');
+var _sourceHelpers = require("./sourceHelpers");
 
-Object.defineProperty(exports, 'lookup', {
+Object.defineProperty(exports, "lookup", {
   enumerable: true,
   get: function get() {
     return _sourceHelpers.lookup;
   }
 });
-Object.defineProperty(exports, 'relationship', {
+Object.defineProperty(exports, "relationship", {
   enumerable: true,
   get: function get() {
     return _sourceHelpers.relationship;
   }
 });
 
-var _languageCommon = require('language-common');
+var _languageCommon = require("language-common");
 
-Object.defineProperty(exports, 'alterState', {
+Object.defineProperty(exports, "alterState", {
   enumerable: true,
   get: function get() {
     return _languageCommon.alterState;
   }
 });
-Object.defineProperty(exports, 'arrayToString', {
+Object.defineProperty(exports, "arrayToString", {
   enumerable: true,
   get: function get() {
     return _languageCommon.arrayToString;
   }
 });
-Object.defineProperty(exports, 'beta', {
+Object.defineProperty(exports, "beta", {
   enumerable: true,
   get: function get() {
     return _languageCommon.beta;
   }
 });
-Object.defineProperty(exports, 'combine', {
+Object.defineProperty(exports, "combine", {
   enumerable: true,
   get: function get() {
     return _languageCommon.combine;
   }
 });
-Object.defineProperty(exports, 'dataPath', {
+Object.defineProperty(exports, "dataPath", {
   enumerable: true,
   get: function get() {
     return _languageCommon.dataPath;
   }
 });
-Object.defineProperty(exports, 'dataValue', {
+Object.defineProperty(exports, "dataValue", {
   enumerable: true,
   get: function get() {
     return _languageCommon.dataValue;
   }
 });
-Object.defineProperty(exports, 'each', {
+Object.defineProperty(exports, "each", {
   enumerable: true,
   get: function get() {
     return _languageCommon.each;
   }
 });
-Object.defineProperty(exports, 'field', {
+Object.defineProperty(exports, "field", {
   enumerable: true,
   get: function get() {
     return _languageCommon.field;
   }
 });
-Object.defineProperty(exports, 'fields', {
+Object.defineProperty(exports, "fields", {
   enumerable: true,
   get: function get() {
     return _languageCommon.fields;
   }
 });
-Object.defineProperty(exports, 'humanProper', {
+Object.defineProperty(exports, "humanProper", {
   enumerable: true,
   get: function get() {
     return _languageCommon.humanProper;
   }
 });
-Object.defineProperty(exports, 'index', {
+Object.defineProperty(exports, "index", {
   enumerable: true,
   get: function get() {
     return _languageCommon.index;
   }
 });
-Object.defineProperty(exports, 'join', {
+Object.defineProperty(exports, "join", {
   enumerable: true,
   get: function get() {
     return _languageCommon.join;
   }
 });
-Object.defineProperty(exports, 'lastReferenceValue', {
+Object.defineProperty(exports, "lastReferenceValue", {
   enumerable: true,
   get: function get() {
     return _languageCommon.lastReferenceValue;
   }
 });
-Object.defineProperty(exports, 'map', {
+Object.defineProperty(exports, "map", {
   enumerable: true,
   get: function get() {
     return _languageCommon.map;
   }
 });
-Object.defineProperty(exports, 'merge', {
+Object.defineProperty(exports, "merge", {
   enumerable: true,
   get: function get() {
     return _languageCommon.merge;
   }
 });
-Object.defineProperty(exports, 'referencePath', {
+Object.defineProperty(exports, "referencePath", {
   enumerable: true,
   get: function get() {
     return _languageCommon.referencePath;
   }
 });
-Object.defineProperty(exports, 'source', {
+Object.defineProperty(exports, "source", {
   enumerable: true,
   get: function get() {
     return _languageCommon.source;
   }
 });
-Object.defineProperty(exports, 'sourceValue', {
+Object.defineProperty(exports, "sourceValue", {
   enumerable: true,
   get: function get() {
     return _languageCommon.sourceValue;
   }
 });
-Object.defineProperty(exports, 'toArray', {
+Object.defineProperty(exports, "toArray", {
   enumerable: true,
   get: function get() {
     return _languageCommon.toArray;
   }
 });
 
-var _jsforce = require('jsforce');
+var _jsforce = require("jsforce");
 
 var _jsforce2 = _interopRequireDefault(_jsforce);
 
-var _lodashFp = require('lodash-fp');
+var _lodashFp = require("lodash-fp");
 
-var _axios = require('axios');
+var _axios = require("axios");
 
 var _axios2 = _interopRequireDefault(_axios);
 
@@ -173,24 +170,27 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 /**
  * Outputs basic information about an sObject to `STDOUT`.
  * @public
- * @example
- *  describe('obj_name')
  * @function
- * @param {String} sObject - API name of the sObject.
- * @param {State} state - Runtime state.
- * @returns {State}
+ * @param {string} sObject - API name of the sObject.
+ * @param {state} state - Runtime state.
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @returns {state} state
+ * @example
+ *  describe('obj_name');
  */
-var describe = exports.describe = (0, _lodashFp.curry)(function (sObject, state) {
+var describe = exports.describe = (0, _lodashFp.curry)(function (sObject, state, callback) {
   var connection = state.connection;
 
 
   return connection.sobject(sObject).describe().then(function (result) {
-    console.log('Label : ' + result.label);
-    console.log('Num of Fields : ' + result.fields.length);
-
-    return _extends({}, state, {
-      references: [result].concat(_toConsumableArray(state.references))
-    });
+    console.log("Label : " + result.label);
+    console.log("Num of Fields : " + result.fields.length);
+    return (0, _languageCommon.composeNextState)(state, result);
+  }).then(function (state) {
+    if (callback) {
+      return callback(state);
+    }
+    return state;
   }).catch(function (err) {
     console.error(err);
     return err;
@@ -200,25 +200,23 @@ var describe = exports.describe = (0, _lodashFp.curry)(function (sObject, state)
 /**
  * Retrieves a Salesforce sObject(s).
  * @public
+ * @function
+ * @param {string} sObject - The sObject to retrieve
+ * @param {string} id - The id of the record
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @param {state} state - Runtime state
+ * @returns {state} state
  * @example
  *  retrieve('ContentVersion', '0684K0000020Au7QAE/VersionData');
- * @function
- * @param {String} sObject - The sObject to retrieve
- * @param {String} id - The id of the record
- * @param {Function} callback - A callback to execute once the record is retrieved
- * @param {State} state - Runtime state
- * @returns {State}
  */
 var retrieve = exports.retrieve = (0, _lodashFp.curry)(function (sObject, id, callback, state) {
   var connection = state.connection;
 
 
-  var finalId = recursivelyExpandReferences(id)(state);
+  var finalId = (0, _languageCommon.recursivelyExpandReferences)(id)(state);
 
   return connection.sobject(sObject).retrieve(finalId).then(function (result) {
-    return _extends({}, state, {
-      references: [result].concat(_toConsumableArray(state.references))
-    });
+    return (0, _languageCommon.composeNextState)(state, result);
   }).then(function (state) {
     if (callback) {
       return callback(state);
@@ -233,79 +231,79 @@ var retrieve = exports.retrieve = (0, _lodashFp.curry)(function (sObject, id, ca
 /**
  * Execute an SOQL query.
  * @public
+ * @function
+ * @param {string} qs - A query string.
+ * @param {state} state - Runtime state.
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @returns {state} state
  * @example
  *  query(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);
- * @function
- * @param {String} qs - A query string.
- * @param {State} state - Runtime state.
- * @returns {Operation}
  */
-var query = exports.query = (0, _lodashFp.curry)(function (qs, state) {
-  var connection = state.connection,
-      references = state.references;
+var query = exports.query = (0, _lodashFp.curry)(function (qs, state, callback) {
+  var connection = state.connection;
 
-  console.log('Executing query: ' + qs);
+  var finalQs = (0, _languageCommon.recursivelyExpandReferences)(qs)(state);
+  console.log("Executing query: " + finalQs);
 
-  return connection.query(qs, function (err, result) {
+  return connection.query(finalQs, function (err, result) {
     if (err) {
       return console.error(err);
     }
 
     console.log(result);
-
-    return _extends({}, state, {
-      references: [result].concat(_toConsumableArray(state.references))
-    });
+    var nextState = (0, _languageCommon.composeNextState)(state, result);
+    if (callback) return callback(nextState);
+    return nextState;
   });
 });
 
 /**
  * Create and execute a bulk job.
  * @public
+ * @function
+ * @param {string} sObject - API name of the sObject.
+ * @param {string} operation - The bulk operation to be performed
+ * @param {string} options - Options passed to the bulk api.
+ * @param {function} fun - A function which takes state and returns an array.
+ * @param {state} state - Runtime state.
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @returns {state} state
  * @example
  *  bulk('Patient__c', 'insert', { failOnError: true }, state => {
  *    return state.data.someArray.map(x => {
  *      return { 'Age__c': x.age, 'Name': x.name }
  *    })
  *  });
- * @function
- * @param {String} sObject - API name of the sObject.
- * @param {String} operation - The bulk operation to be performed
- * @param {String} options - Options passed to the bulk api.
- * @param {Function} fun - A function which takes state and returns an array.
- * @param {State} state - Runtime state.
- * @returns {Operation}
  */
-var bulk = exports.bulk = (0, _lodashFp.curry)(function (sObject, operation, options, fun, state) {
-  var connection = state.connection,
-      references = state.references;
+var bulk = exports.bulk = (0, _lodashFp.curry)(function (sObject, operation, options, fun, state, callback) {
+  var connection = state.connection;
   var failOnError = options.failOnError,
       allowNoOp = options.allowNoOp;
 
   var finalAttrs = fun(state);
 
   if (allowNoOp && finalAttrs.length === 0) {
-    console.info('No items in ' + sObject + ' array. Skipping bulk ' + operation + ' operation.');
+    console.info("No items in " + sObject + " array. Skipping bulk " + operation + " operation.");
     return state;
   }
 
-  console.info('Creating bulk ' + operation + ' job for ' + sObject, finalAttrs);
+  console.info("Creating bulk " + operation + " job for " + sObject, finalAttrs);
   var job = connection.bulk.createJob(sObject, operation, options);
 
-  console.info('Creating batch for job.');
+  console.info("Creating batch for job.");
   var batch = job.createBatch();
 
-  console.info('Executing batch.');
+  console.info("Executing batch.");
   batch.execute(finalAttrs);
 
-  return batch.on('queue', function (batchInfo) {
+  return batch.on("queue", function (batchInfo) {
     console.info(batchInfo);
     var batchId = batchInfo.id;
     var batch = job.batch(batchId);
 
-    batch.on('error', function (err) {
+    batch.on("error", function (err) {
       job.close();
-      console.error('Request error:');
+      console.error("Request error:");
       throw err;
     });
 
@@ -317,13 +315,13 @@ var bulk = exports.bulk = (0, _lodashFp.curry)(function (sObject, operation, opt
     });
 
     if (failOnError && errors.length > 0) {
-      console.error('Errors detected:');
+      console.error("Errors detected:");
       throw res;
     } else {
-      console.log('Result : ' + JSON.stringify(res, null, 2));
-      return _extends({}, state, {
-        references: [res].concat(_toConsumableArray(state.references))
-      });
+      console.log("Result : " + JSON.stringify(res, null, 2));
+      var nextState = (0, _languageCommon.composeNextState)(state, res);
+      if (callback) return callback(nextState);
+      return nextState;
     }
   });
 });
@@ -331,198 +329,208 @@ var bulk = exports.bulk = (0, _lodashFp.curry)(function (sObject, operation, opt
 /**
  * Create a new object.
  * @public
+ * @function
+ * @param {string} sObject - API name of the sObject.
+ * @param {object} attrs - Field attributes for the new object.
+ * @param {state} state - Runtime state.
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @returns {state} state
  * @example
  *  create('obj_name', {
  *    attr1: "foo",
  *    attr2: "bar"
  *  })
- * @function
- * @param {String} sObject - API name of the sObject.
- * @param {Object} attrs - Field attributes for the new object.
- * @param {State} state - Runtime state.
- * @returns {Operation}
  */
-var create = exports.create = (0, _lodashFp.curry)(function (sObject, attrs, state) {
+var create = exports.create = (0, _lodashFp.curry)(function (sObject, attrs, state, callback) {
   var connection = state.connection,
       references = state.references;
 
-  var finalAttrs = expandReferences(state, attrs);
-  console.info('Creating ' + sObject, finalAttrs);
+  var finalAttrs = (0, _languageCommon.recursivelyExpandReferences)(attrs)(state);
+  console.info("Creating " + sObject, finalAttrs);
 
   return connection.create(sObject, finalAttrs).then(function (recordResult) {
-    console.log('Result : ' + JSON.stringify(recordResult));
-    return _extends({}, state, {
-      references: [recordResult].concat(_toConsumableArray(state.references))
-    });
+    console.log("Result : " + JSON.stringify(recordResult));
+    var nextState = (0, _languageCommon.composeNextState)(state, recordResult);
+    if (callback) return callback(nextState);
+    return nextState;
   });
 });
 
 /**
  * Create a new object if conditions are met.
  * @public
+ * @function
+ * @param {boolean} logical - a logical statement that will be evaluated.
+ * @param {string} sObject - API name of the sObject.
+ * @param {object} attrs - Field attributes for the new object.
+ * @param {state} state - Runtime state.
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @returns {state} state
  * @example
  *  createIf(true, 'obj_name', {
  *    attr1: "foo",
  *    attr2: "bar"
  *  })
- * @function
- * @param {boolean} logical - a logical statement that will be evaluated.
- * @param {String} sObject - API name of the sObject.
- * @param {Object} attrs - Field attributes for the new object.
- * @param {State} state - Runtime state.
- * @returns {Operation}
  */
-var createIf = exports.createIf = (0, _lodashFp.curry)(function (logical, sObject, attrs, state) {
-  var connection = state.connection,
-      references = state.references;
+var createIf = exports.createIf = (0, _lodashFp.curry)(function (logical, sObject, attrs, state, callback) {
+  var connection = state.connection;
 
-  var finalAttrs = expandReferences(state, attrs);
+  var finalAttrs = (0, _languageCommon.recursivelyExpandReferences)(attrs)(state);
   if (logical) {
-    console.info('Creating ' + sObject, finalAttrs);
+    console.info("Creating " + sObject, finalAttrs);
   } else {
-    console.info('Not creating ' + sObject + ' because logical is false.');
+    console.info("Not creating " + sObject + " because logical is false.");
   }
 
   if (logical) {
     return connection.create(sObject, finalAttrs).then(function (recordResult) {
-      console.log('Result : ' + JSON.stringify(recordResult));
-      return _extends({}, state, {
-        references: [recordResult].concat(_toConsumableArray(state.references))
-      });
+      console.log("Result : " + JSON.stringify(recordResult));
+      var nextState = (0, _languageCommon.composeNextState)(state, recordResult);
+      if (callback) return callback(nextState);
+      return nextState;
     });
   } else {
-    return _extends({}, state);
+    var nextState = _extends({}, state);
+    if (callback) return callback(nextState);
+    return nextState;
   }
 });
 
 /**
  * Upsert an object.
  * @public
+ * @function
+ * @param {string} sObject - API name of the sObject.
+ * @param {string} externalId - ID.
+ * @param {object} attrs - Field attributes for the new object.
+ * @param {state} state - Runtime state.
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @returns {state} state
  * @example
  *  upsert('obj_name', 'ext_id', {
  *    attr1: "foo",
  *    attr2: "bar"
  *  })
- * @function
- * @param {String} sObject - API name of the sObject.
- * @param {String} externalId - ID.
- * @param {Object} attrs - Field attributes for the new object.
- * @param {State} state - Runtime state.
- * @returns {Operation}
  */
-var upsert = exports.upsert = (0, _lodashFp.curry)(function (sObject, externalId, attrs, state) {
-  var connection = state.connection,
-      references = state.references;
+var upsert = exports.upsert = (0, _lodashFp.curry)(function (sObject, externalId, attrs, state, callback) {
+  var connection = state.connection;
 
-  var finalAttrs = expandReferences(state, attrs);
-  console.info('Upserting ' + sObject + ' with externalId', externalId, ':', finalAttrs);
+  var finalAttrs = (0, _languageCommon.recursivelyExpandReferences)(attrs)(state);
+  var finalExternalId = (0, _languageCommon.recursivelyExpandReferences)(externalId)(state);
+  console.info("Upserting " + sObject + " with externalId", finalExternalId, ":", finalAttrs);
 
-  return connection.upsert(sObject, finalAttrs, externalId).then(function (recordResult) {
-    console.log('Result : ' + JSON.stringify(recordResult));
-    return _extends({}, state, {
-      references: [recordResult].concat(_toConsumableArray(state.references))
-    });
+  return connection.upsert(sObject, finalAttrs, finalExternalId).then(function (recordResult) {
+    console.log("Result : " + JSON.stringify(recordResult));
+    var nextState = (0, _languageCommon.composeNextState)(state, recordResult);
+    if (callback) return callback(nextState);
+    return nextState;
   });
 });
 
 /**
  * Upsert if conditions are met.
  * @public
+ * @function
+ * @param {boolean} logical - a logical statement that will be evaluated.
+ * @param {string} sObject - API name of the sObject.
+ * @param {string} externalId - ID.
+ * @param {object} attrs - Field attributes for the new object.
+ * @param {state} state - Runtime state.
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @returns {state} state
  * @example
  *  upsertIf(true, 'obj_name', 'ext_id', {
  *    attr1: "foo",
  *    attr2: "bar"
  *  })
- * @function
- * @param {boolean} logical - a logical statement that will be evaluated.
- * @param {String} sObject - API name of the sObject.
- * @param {String} externalId - ID.
- * @param {Object} attrs - Field attributes for the new object.
- * @param {State} state - Runtime state.
- * @returns {Operation}
  */
-var upsertIf = exports.upsertIf = (0, _lodashFp.curry)(function (logical, sObject, externalId, attrs, state) {
-  var connection = state.connection,
-      references = state.references;
+var upsertIf = exports.upsertIf = (0, _lodashFp.curry)(function (logical, sObject, externalId, attrs, state, callback) {
+  var connection = state.connection;
 
-  var finalAttrs = expandReferences(state, attrs);
+  var finalAttrs = (0, _languageCommon.recursivelyExpandReferences)(attrs)(state);
+  var finalExternalId = (0, _languageCommon.recursivelyExpandReferences)(externalId)(state);
   if (logical) {
-    console.info('Upserting ' + sObject + ' with externalId', externalId, ':', finalAttrs);
+    console.info("Upserting " + sObject + " with externalId", finalExternalId, ":", finalAttrs);
   } else {
-    console.info('Not upserting ' + sObject + ' because logical is false.');
+    console.info("Not upserting " + sObject + " because logical is false.");
   }
 
   if (logical) {
-    return connection.upsert(sObject, finalAttrs, externalId).then(function (recordResult) {
-      console.log('Result : ' + JSON.stringify(recordResult));
-      return _extends({}, state, {
-        references: [recordResult].concat(_toConsumableArray(state.references))
-      });
+    return connection.upsert(sObject, finalAttrs, finalExternalId).then(function (recordResult) {
+      console.log("Result : " + JSON.stringify(recordResult));
+      var nextState = (0, _languageCommon.composeNextState)(state, recordResult);
+      if (callback) return callback(nextState);
+      return nextState;
     });
   } else {
-    return _extends({}, state);
+    var nextState = _extends({}, state);
+    if (callback) return callback(nextState);
+    return nextState;
   }
 });
 
 /**
  * Update an object.
  * @public
+ * @function
+ * @param {string} sObject - API name of the sObject.
+ * @param {object} attrs - Field attributes for the new object.
+ * @param {state} state - Runtime state.
+ * @param {operation} callback - Function which takes state and returns a Promise
+ * @returns {state} state
  * @example
  *  update('obj_name', {
  *    attr1: "foo",
  *    attr2: "bar"
  *  })
- * @function
- * @param {String} sObject - API name of the sObject.
- * @param {Object} attrs - Field attributes for the new object.
- * @param {State} state - Runtime state.
- * @returns {Operation}
  */
-var update = exports.update = (0, _lodashFp.curry)(function (sObject, attrs, state) {
-  var connection = state.connection,
-      references = state.references;
+var update = exports.update = (0, _lodashFp.curry)(function (sObject, attrs, state, callback) {
+  var connection = state.connection;
 
-  var finalAttrs = expandReferences(state, attrs);
-  console.info('Updating ' + sObject, finalAttrs);
+  var finalAttrs = (0, _languageCommon.recursivelyExpandReferences)(attrs)(state);
+  console.info("Updating " + sObject, finalAttrs);
 
   return connection.update(sObject, finalAttrs).then(function (recordResult) {
-    console.log('Result : ' + JSON.stringify(recordResult));
-    return _extends({}, state, {
-      references: [recordResult].concat(_toConsumableArray(state.references))
-    });
+    console.log("Result : " + JSON.stringify(recordResult));
+    var nextState = (0, _languageCommon.composeNextState)(state, recordResult);
+    if (callback) return callback(nextState);
+    return nextState;
   });
 });
 
 /**
  * Get a reference ID by an index.
  * @public
- * @example
- *  reference(0)
  * @function
  * @param {number} position - Position for references array.
- * @param {State} state - Array of references.
- * @returns {State}
+ * @param {state} state - Runtime state.
+ * @param {operation} [callback] - Function which takes state and returns a Promise
+ * @returns {state} state
+ * @example
+ *  reference(0)
  */
-var reference = exports.reference = (0, _lodashFp.curry)(function (position, state) {
+var reference = exports.reference = (0, _lodashFp.curry)(function (position, state, callback) {
   var references = state.references;
 
-  return references[position].id;
+  var nextState = (0, _languageCommon.composeNextState)(state, references[position].id);
+  if (callback) return callback(nextState);
+  return nextState;
 });
 
 /**
  * Creates a connection.
- * @example
- *  createConnection(state)
  * @function
- * @param {State} state - Runtime state.
- * @returns {State}
+ * @param {state} state - Runtime state.
+ * @returns {state} state
+ * @example
+ * createConnection(state)
  */
 function createConnection(state) {
   var loginUrl = state.configuration.loginUrl;
 
 
   if (!loginUrl) {
-    throw new Error('loginUrl missing from configuration.');
+    throw new Error("loginUrl missing from configuration.");
   }
 
   return _extends({}, state, { connection: new _jsforce2.default.Connection({ loginUrl: loginUrl }) });
@@ -530,11 +538,11 @@ function createConnection(state) {
 
 /**
  * Performs a login.
+ * @function
+ * @param {state} state - Runtime state.
+ * @returns {state} state
  * @example
  *  login(state)
- * @function
- * @param {State} state - Runtime state.
- * @returns {State}
  */
 function login(state) {
   var _state$configuration = state.configuration,
@@ -543,7 +551,7 @@ function login(state) {
       securityToken = _state$configuration.securityToken;
   var connection = state.connection;
 
-  console.info('Logging in as ' + username + '.');
+  console.info("Logging in as " + username + ".");
 
   return connection.login(username, password + securityToken)
   // NOTE: Uncomment this to debug connection issues.
@@ -560,8 +568,8 @@ function login(state) {
 /**
  * Executes an operation.
  * @function
- * @param {Operation} operations - Operations
- * @returns {State}
+ * @param {operation} operations - Operations
+ * @returns {state}
  */
 function execute() {
   for (var _len = arguments.length, operations = Array(_len), _key = 0; _key < _len; _key++) {
@@ -587,11 +595,11 @@ function execute() {
 
 /**
  * Removes unserializable keys from the state.
+ * @function
+ * @param {state} state - Runtime state.
+ * @returns {state} state
  * @example
  *  cleanupState(state)
- * @function
- * @param {State} state
- * @returns {State}
  */
 function cleanupState(state) {
   delete state.connection;
@@ -601,13 +609,13 @@ function cleanupState(state) {
 /**
  * Flattens an array of operations.
  * @public
+ * @function
+ * @returns {array}
  * @example
  *  steps(
  *    createIf(params),
  *    update(params)
  *  )
- * @function
- * @returns {Array}
  */
 function steps() {
   for (var _len2 = arguments.length, operations = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
@@ -615,49 +623,6 @@ function steps() {
   }
 
   return (0, _lodashFp.flatten)(operations);
-}
-
-/**
- * Recursively expand object|number|string|boolean|array, each time resolving function calls and returning the resolved values
- * @param {any} thing - Thing to expand
- * @returns {object|number|string|boolean|array} expandedResult
- */
-function recursivelyExpandReferences(thing) {
-  return function (state) {
-    if ((typeof thing === 'undefined' ? 'undefined' : _typeof(thing)) !== 'object') return typeof thing == 'function' ? thing(state) : thing;
-    var result = (0, _lodashFp.mapValues)(function (value) {
-      if (Array.isArray(value)) {
-        return value.map(function (item) {
-          return recursivelyExpandReferences(item)(state);
-        });
-      } else {
-        return recursivelyExpandReferences(value)(state);
-      }
-    })(thing);
-    if (Array.isArray(thing)) result = Object.values(result);
-    return result;
-  };
-}
-
-/**
- * Expands references.
- * @example
- *  expandReferences(
- *    state,
- *    {
- *      attr1: "foo",
- *      attr2: "bar"
- *    }
- *  )
- * @function
- * @param {State} state - Runtime state.
- * @param {Object} attrs - Field attributes for the new object.
- * @returns {State}
- */
-function expandReferences(state, attrs) {
-  return (0, _lodashFp.mapValues)(function (value) {
-    return typeof value == 'function' ? value(state) : value;
-  })(attrs);
 }
 
 // Note that we expose the entire axios package to the user here.


### PR DESCRIPTION
This PR fixes #15 but needs the following before merging:
1. `recursivelyExpandReferences` is not implemented in `language-common` yet. The operations have been updated to use `recursivelyExpandReferences` but may fail since it is not exported from `language-common`
2. Tests for each of the operations not yet passing as `recursivelyExpandReferences` is blocking.

@taylordowns2000 and @stuartc kindly advise if `recursivelyExpandReferences`, in this context should be replaced with the exported `expandReferences` from `language common`.