### PR TITLE
Use expandReferences from language-common

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -5,7 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.execute = execute;
 exports.steps = steps;
-exports.recursivelyExpandReferences = recursivelyExpandReferences;
 Object.defineProperty(exports, "alterState", {
   enumerable: true,
   get: function () {
@@ -208,7 +207,7 @@ const retrieve = (0, _lodashFp.curry)(function (sObject, id, callback, state) {
   let {
     connection
   } = state;
-  const finalId = recursivelyExpandReferences(id)(state);
+  const finalId = (0, _languageCommon.expandReferences)(id)(state);
   return connection.sobject(sObject).retrieve(finalId).then(result => {
     return { ...state,
       references: [result, ...state.references]
@@ -238,8 +237,7 @@ const retrieve = (0, _lodashFp.curry)(function (sObject, id, callback, state) {
 exports.retrieve = retrieve;
 const query = (0, _lodashFp.curry)(function (qs, state) {
   let {
-    connection,
-    references
+    connection
   } = state;
   console.log(`Executing query: ${qs}`);
   return connection.query(qs, function (err, result) {
@@ -274,8 +272,7 @@ const query = (0, _lodashFp.curry)(function (qs, state) {
 exports.query = query;
 const bulk = (0, _lodashFp.curry)(function (sObject, operation, options, fun, state) {
   let {
-    connection,
-    references
+    connection
   } = state;
   let {
     failOnError,
@@ -339,10 +336,9 @@ const bulk = (0, _lodashFp.curry)(function (sObject, operation, options, fun, st
 exports.bulk = bulk;
 const create = (0, _lodashFp.curry)(function (sObject, attrs, state) {
   let {
-    connection,
-    references
+    connection
   } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  const finalAttrs = (0, _languageCommon.expandReferences)(attrs)(state);
   console.info(`Creating ${sObject}`, finalAttrs);
   return connection.create(sObject, finalAttrs).then(function (recordResult) {
     console.log('Result : ' + JSON.stringify(recordResult));
@@ -370,10 +366,9 @@ const create = (0, _lodashFp.curry)(function (sObject, attrs, state) {
 exports.create = create;
 const createIf = (0, _lodashFp.curry)(function (logical, sObject, attrs, state) {
   let {
-    connection,
-    references
+    connection
   } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  const finalAttrs = (0, _languageCommon.expandReferences)(attrs)(state);
 
   if (logical) {
     console.info(`Creating ${sObject}`, finalAttrs);
@@ -412,10 +407,9 @@ const createIf = (0, _lodashFp.curry)(function (logical, sObject, attrs, state) 
 exports.createIf = createIf;
 const upsert = (0, _lodashFp.curry)(function (sObject, externalId, attrs, state) {
   let {
-    connection,
-    references
+    connection
   } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  const finalAttrs = (0, _languageCommon.expandReferences)(attrs)(state);
   console.info(`Upserting ${sObject} with externalId`, externalId, ':', finalAttrs);
   return connection.upsert(sObject, finalAttrs, externalId).then(function (recordResult) {
     console.log('Result : ' + JSON.stringify(recordResult));
@@ -444,10 +438,9 @@ const upsert = (0, _lodashFp.curry)(function (sObject, externalId, attrs, state)
 exports.upsert = upsert;
 const upsertIf = (0, _lodashFp.curry)(function (logical, sObject, externalId, attrs, state) {
   let {
-    connection,
-    references
+    connection
   } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  const finalAttrs = (0, _languageCommon.expandReferences)(attrs)(state);
 
   if (logical) {
     console.info(`Upserting ${sObject} with externalId`, externalId, ':', finalAttrs);
@@ -485,10 +478,9 @@ const upsertIf = (0, _lodashFp.curry)(function (logical, sObject, externalId, at
 exports.upsertIf = upsertIf;
 const update = (0, _lodashFp.curry)(function (sObject, attrs, state) {
   let {
-    connection,
-    references
+    connection
   } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  const finalAttrs = (0, _languageCommon.expandReferences)(attrs)(state);
   console.info(`Updating ${sObject}`, finalAttrs);
   return connection.update(sObject, finalAttrs).then(function (recordResult) {
     console.log('Result : ' + JSON.stringify(recordResult));
@@ -624,51 +616,6 @@ function cleanupState(state) {
 
 function steps(...operations) {
   return (0, _lodashFp.flatten)(operations);
-}
-/**
- * Recursively expand object|number|string|boolean|array, each time resolving function calls and returning the resolved values
- * @param {any} thing - Thing to expand
- * @returns {object|number|string|boolean|array} expandedResult
- */
-
-
-function recursivelyExpandReferences(thing) {
-  return state => {
-    if (typeof thing !== 'object') return typeof thing == 'function' ? thing(state) : thing;
-    let result = (0, _lodashFp.mapValues)(function (value) {
-      if (Array.isArray(value)) {
-        return value.map(item => {
-          return recursivelyExpandReferences(item)(state);
-        });
-      } else {
-        return recursivelyExpandReferences(value)(state);
-      }
-    })(thing);
-    if (Array.isArray(thing)) result = Object.values(result);
-    return result;
-  };
-}
-/**
- * Expands references.
- * @example
- * expandReferences(
- *   state,
- *   {
- *     attr1: "foo",
- *     attr2: "bar"
- *   }
- * )
- * @function
- * @param {State} state - Runtime state.
- * @param {Object} attrs - Field attributes for the new object.
- * @returns {State}
- */
-
-
-function expandReferences(state, attrs) {
-  return (0, _lodashFp.mapValues)(function (value) {
-    return typeof value == 'function' ? value(state) : value;
-  })(attrs);
 }
 
 exports.axios = _axios.default;

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -184,9 +184,6 @@ const describe = (0, _lodashFp.curry)(function (sObject, state) {
     return { ...state,
       references: [result, ...state.references]
     };
-  }).catch(function (err) {
-    console.error(err);
-    return err;
   });
 });
 /**
@@ -218,13 +215,12 @@ const retrieve = (0, _lodashFp.curry)(function (sObject, id, callback, state) {
     }
 
     return state;
-  }).catch(function (err) {
-    console.error(err);
-    return err;
   });
 });
 /**
  * Execute an SOQL query.
+ * Note that in an event of a query error,
+ * error logs will be printed but the operation will not throw the error.
  * @public
  * @example
  * query(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,21 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Adaptor = exports.FakeAdaptor = undefined;
+exports.FakeAdaptor = exports.Adaptor = exports.default = void 0;
 
-var _Adaptor = require('./Adaptor');
+var Adaptor = _interopRequireWildcard(require("./Adaptor"));
 
-var Adaptor = _interopRequireWildcard(_Adaptor);
-
-var _FakeAdaptor = require('./FakeAdaptor');
-
-var FakeAdaptor = _interopRequireWildcard(_FakeAdaptor);
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
-
-exports.default = Adaptor;
-exports.FakeAdaptor = FakeAdaptor;
 exports.Adaptor = Adaptor;
+
+var FakeAdaptor = _interopRequireWildcard(require("./FakeAdaptor"));
+
+exports.FakeAdaptor = FakeAdaptor;
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+var _default = Adaptor;
+exports.default = _default;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,9 +1183,9 @@
       }
     },
     "@openfn/language-common": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@openfn/language-common/-/language-common-1.2.6.tgz",
-      "integrity": "sha512-lQ6GXZTa5bsInylCi6H0u6bNUntkCI2yGLNioST42JAmDJ8oWjfyoOuNd2dSynj/uPsqi8v5dwVFCZL7jR2iww==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@openfn/language-common/-/language-common-1.2.8.tgz",
+      "integrity": "sha512-qPsulJhado7ukp01V18mb0t9S5LIsYrtanABb5wN1bbWx+E8Tvg62fJje9oAv3O7o7kmpNl8bs6VJmJTbMc/6g==",
       "requires": {
         "axios": "^0.21.1",
         "jsonpath-plus": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lib/"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.2.6",
+    "@openfn/language-common": "1.2.8",
     "JSONPath": "^0.10.0",
     "jsforce": "^1.9.3",
     "lodash-fp": "^0.10.2",

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -11,9 +11,12 @@
  * @param {State} state
  */
 
-import { execute as commonExecute } from '@openfn/language-common';
+import {
+  execute as commonExecute,
+  expandReferences,
+} from '@openfn/language-common';
 import jsforce from 'jsforce';
-import { curry, mapValues, flatten } from 'lodash-fp';
+import { curry, flatten } from 'lodash-fp';
 
 /**
  * Outputs basic information about an sObject to `STDOUT`.
@@ -61,7 +64,7 @@ export const describe = curry(function (sObject, state) {
 export const retrieve = curry(function (sObject, id, callback, state) {
   let { connection } = state;
 
-  const finalId = recursivelyExpandReferences(id)(state);
+  const finalId = expandReferences(id)(state);
 
   return connection
     .sobject(sObject)
@@ -95,7 +98,7 @@ export const retrieve = curry(function (sObject, id, callback, state) {
  * @returns {Operation}
  */
 export const query = curry(function (qs, state) {
-  let { connection, references } = state;
+  let { connection } = state;
   console.log(`Executing query: ${qs}`);
 
   return connection.query(qs, function (err, result) {
@@ -130,7 +133,7 @@ export const query = curry(function (qs, state) {
  * @returns {Operation}
  */
 export const bulk = curry(function (sObject, operation, options, fun, state) {
-  let { connection, references } = state;
+  let { connection } = state;
   let { failOnError, allowNoOp } = options;
   const finalAttrs = fun(state);
 
@@ -198,8 +201,8 @@ export const bulk = curry(function (sObject, operation, options, fun, state) {
  * @returns {Operation}
  */
 export const create = curry(function (sObject, attrs, state) {
-  let { connection, references } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  let { connection } = state;
+  const finalAttrs = expandReferences(attrs)(state);
   console.info(`Creating ${sObject}`, finalAttrs);
 
   return connection.create(sObject, finalAttrs).then(function (recordResult) {
@@ -227,8 +230,8 @@ export const create = curry(function (sObject, attrs, state) {
  * @returns {Operation}
  */
 export const createIf = curry(function (logical, sObject, attrs, state) {
-  let { connection, references } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  let { connection } = state;
+  const finalAttrs = expandReferences(attrs)(state);
   if (logical) {
     console.info(`Creating ${sObject}`, finalAttrs);
   } else {
@@ -266,8 +269,8 @@ export const createIf = curry(function (logical, sObject, attrs, state) {
  * @returns {Operation}
  */
 export const upsert = curry(function (sObject, externalId, attrs, state) {
-  let { connection, references } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  let { connection } = state;
+  const finalAttrs = expandReferences(attrs)(state);
   console.info(
     `Upserting ${sObject} with externalId`,
     externalId,
@@ -309,8 +312,8 @@ export const upsertIf = curry(function (
   attrs,
   state
 ) {
-  let { connection, references } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  let { connection } = state;
+  const finalAttrs = expandReferences(attrs)(state);
   if (logical) {
     console.info(
       `Upserting ${sObject} with externalId`,
@@ -354,8 +357,8 @@ export const upsertIf = curry(function (
  * @returns {Operation}
  */
 export const update = curry(function (sObject, attrs, state) {
-  let { connection, references } = state;
-  const finalAttrs = expandReferences(state, attrs);
+  let { connection } = state;
+  const finalAttrs = expandReferences(attrs)(state);
   console.info(`Updating ${sObject}`, finalAttrs);
 
   return connection.update(sObject, finalAttrs).then(function (recordResult) {
@@ -481,50 +484,6 @@ function cleanupState(state) {
  */
 export function steps(...operations) {
   return flatten(operations);
-}
-
-/**
- * Recursively expand object|number|string|boolean|array, each time resolving function calls and returning the resolved values
- * @param {any} thing - Thing to expand
- * @returns {object|number|string|boolean|array} expandedResult
- */
-export function recursivelyExpandReferences(thing) {
-  return state => {
-    if (typeof thing !== 'object')
-      return typeof thing == 'function' ? thing(state) : thing;
-    let result = mapValues(function (value) {
-      if (Array.isArray(value)) {
-        return value.map(item => {
-          return recursivelyExpandReferences(item)(state);
-        });
-      } else {
-        return recursivelyExpandReferences(value)(state);
-      }
-    })(thing);
-    if (Array.isArray(thing)) result = Object.values(result);
-    return result;
-  };
-}
-
-/**
- * Expands references.
- * @example
- * expandReferences(
- *   state,
- *   {
- *     attr1: "foo",
- *     attr2: "bar"
- *   }
- * )
- * @function
- * @param {State} state - Runtime state.
- * @param {Object} attrs - Field attributes for the new object.
- * @returns {State}
- */
-function expandReferences(state, attrs) {
-  return mapValues(function (value) {
-    return typeof value == 'function' ? value(state) : value;
-  })(attrs);
 }
 
 export { lookup, relationship } from './sourceHelpers';

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -42,10 +42,6 @@ export const describe = curry(function (sObject, state) {
         ...state,
         references: [result, ...state.references],
       };
-    })
-    .catch(function (err) {
-      console.error(err);
-      return err;
     });
 });
 
@@ -80,15 +76,13 @@ export const retrieve = curry(function (sObject, id, callback, state) {
         return callback(state);
       }
       return state;
-    })
-    .catch(function (err) {
-      console.error(err);
-      return err;
     });
 });
 
 /**
  * Execute an SOQL query.
+ * Note that in an event of a query error,
+ * error logs will be printed but the operation will not throw the error.
  * @public
  * @example
  * query(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);


### PR DESCRIPTION
**Language-salesforce** is using the **old way of expanding references** which fail **recursive expansion of objects** passed to its operations. See example expression [here](https://github.com/OpenFn/grassroot-soccer/blob/4aa17d3c59b1ab2d91d83f853b08ed8ee2e384c3/jobs/upsertAttendance.js#L67). 

This PR Upgrades its `expandReferences` dependency to using `expandReferences` from `language-common`. Merging this PR is part of the fix for [this issue](https://github.com/OpenFn/grassroot-soccer/issues/3). So testing for  [these job expressions](https://github.com/OpenFn/grassroot-soccer/tree/master/jobs) is **blocked** until this PR is merged!

Cc:
@daissatou2 @aleksa-krolls 