### PR TITLE
Expand the logical argument for upsertIf

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -437,6 +437,7 @@ const upsertIf = (0, _lodashFp.curry)(function (logical, sObject, externalId, at
     connection
   } = state;
   const finalAttrs = (0, _languageCommon.expandReferences)(attrs)(state);
+  logical = (0, _languageCommon.expandReferences)(logical)(state);
 
   if (logical) {
     console.info(`Upserting ${sObject} with externalId`, externalId, ':', finalAttrs);

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -308,6 +308,8 @@ export const upsertIf = curry(function (
 ) {
   let { connection } = state;
   const finalAttrs = expandReferences(attrs)(state);
+  logical = expandReferences(logical)(state);
+  
   if (logical) {
     console.info(
       `Upserting ${sObject} with externalId`,


### PR DESCRIPTION
This PR allows `upsertIf` to expand the `logical` parameter when given a **function as the argument**. For example, currently, the below expression would fail because the first argument(`logical`) is a `function` and would never resolve to the expected  value from state :

```
upsertIf(
  dataValue('perform_a_risk_assessment'),
  'Risk_Assessment__c',
  'CommCare_Ext_ID__c',
  fields(
    field('CommCare_Ext_ID__c', dataValue('id')),
    ...
 )
)
```