### PR TITLE
Expand query string with expandReferences

### DIFF
--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -235,6 +235,7 @@ const query = (0, _lodashFp.curry)(function (qs, state) {
   let {
     connection
   } = state;
+  qs = (0, _languageCommon.expandReferences)(qs)(state);
   console.log(`Executing query: ${qs}`);
   return connection.query(qs, function (err, result) {
     if (err) {

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -93,6 +93,7 @@ export const retrieve = curry(function (sObject, id, callback, state) {
  */
 export const query = curry(function (qs, state) {
   let { connection } = state;
+  qs = expandReferences(qs)(state)
   console.log(`Executing query: ${qs}`);
 
   return connection.query(qs, function (err, result) {


### PR DESCRIPTION
This PR allows `query` to expand the `qs` parameter when given a **function as the argument**. For example, currently, the below expression would fail because the first argument(`qs`) is a `function` and would never resolve to the expected  value from state :

```
beta.each(
  '$.items[*]',
  query(
    state => `SELECT CommCare_Ext_ID__c, Session_1__c,
        FROM Attendance__c
        WHERE CommCare_Ext_ID__c = '${state.data.CommCare_Ext_ID__c}'
        `
  )
);
```