### PR TITLE
Use common 1.6.1 and scrubEmojis

### DIFF
--- a/ast.json
+++ b/ast.json
@@ -1518,7 +1518,7 @@
         "str"
       ],
       "docs": {
-        "description": "Subsitutes underscores for spaces and proper-cases a string",
+        "description": "Substitutes underscores for spaces and proper-cases a string",
         "tags": [
           {
             "title": "public",
@@ -1556,12 +1556,13 @@
       "valid": true
     },
     {
-      "name": "removeEmojis",
+      "name": "scrubEmojis",
       "params": [
-        "text"
+        "text",
+        "replacementChars"
       ],
       "docs": {
-        "description": "Removes emojis from a string of text",
+        "description": "Replaces emojis in a string.",
         "tags": [
           {
             "title": "public",
@@ -1570,7 +1571,7 @@
           },
           {
             "title": "example",
-            "description": "removeEmojis('Dove🕊️⭐ 29')"
+            "description": "scrubEmojis('Dove🕊️⭐ 29')"
           },
           {
             "title": "function",
@@ -1585,6 +1586,15 @@
               "name": "string"
             },
             "name": "text"
+          },
+          {
+            "title": "param",
+            "description": "Characters that replace the emojis",
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "replacementChars"
           },
           {
             "title": "returns",

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -114,10 +114,10 @@ Object.defineProperty(exports, "referencePath", {
     return _languageCommon.referencePath;
   }
 });
-Object.defineProperty(exports, "removeEmojis", {
+Object.defineProperty(exports, "scrubEmojis", {
   enumerable: true,
   get: function () {
-    return _languageCommon.removeEmojis;
+    return _languageCommon.scrubEmojis;
   }
 });
 Object.defineProperty(exports, "source", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1174,9 +1174,9 @@
       }
     },
     "@openfn/language-common": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@openfn/language-common/-/language-common-1.6.0.tgz",
-      "integrity": "sha512-igENgJETMfiOX/zlqWkuiDwAxOKduA86S/pl+2ff2HBcAvC/2wG3w50whoeTuMLx5/5hcfhZ8EsbG+U69on8XA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@openfn/language-common/-/language-common-1.6.1.tgz",
+      "integrity": "sha512-L7USop+SFwZF9KnTUBj598M0ZnbscQ1Ccclwm+5cArdJvB7hbc7DOKOwHGfWSmeB/OXOvzhBmukXQ9QPz+7+yA==",
       "requires": {
         "axios": "^0.21.4",
         "jsonpath-plus": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ast.json"
   ],
   "dependencies": {
-    "@openfn/language-common": "1.6.0",
+    "@openfn/language-common": "1.6.1",
     "axios": "^0.21.1",
     "jsforce": "^1.10.0",
     "JSONPath": "^0.10.0",

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -589,7 +589,7 @@ export {
   map,
   merge,
   referencePath,
-  removeEmojis,
+  scrubEmojis,
   source,
   sourceValue,
   toArray,


### PR DESCRIPTION
In common, The function removeEmojis is now renamed scrubEmojis and implemented in a way that handles potential security vulnerabilities.
In this commit we're adding the new version of common and scrubEmojis.