### PR TITLE
create directQuery function

### DIFF
--- a/ast.json
+++ b/ast.json
@@ -247,6 +247,60 @@
       "valid": true
     },
     {
+      "name": "directQuery",
+      "params": [
+        "qs",
+        "state"
+      ],
+      "docs": {
+        "description": "Execute an SOQL query and return result object.\nNote that in an event of a query error,\nerror logs will be printed but the operation will not throw the error.",
+        "tags": [
+          {
+            "title": "public",
+            "description": null,
+            "type": null
+          },
+          {
+            "title": "example",
+            "description": "directQuery(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);"
+          },
+          {
+            "title": "constructor",
+            "description": null,
+            "type": null,
+            "name": null
+          },
+          {
+            "title": "param",
+            "description": "A query string.",
+            "type": {
+              "type": "NameExpression",
+              "name": "String"
+            },
+            "name": "qs"
+          },
+          {
+            "title": "param",
+            "description": "Runtime state.",
+            "type": {
+              "type": "NameExpression",
+              "name": "State"
+            },
+            "name": "state"
+          },
+          {
+            "title": "returns",
+            "description": null,
+            "type": {
+              "type": "NameExpression",
+              "name": "Operation"
+            }
+          }
+        ]
+      },
+      "valid": true
+    },
+    {
       "name": "bulk",
       "params": [
         "sObject",

--- a/lib/Adaptor.js
+++ b/lib/Adaptor.js
@@ -162,7 +162,7 @@ Object.defineProperty(exports, "toArray", {
     return _languageCommon.toArray;
   }
 });
-exports.reference = exports.update = exports.upsertIf = exports.upsert = exports.createIf = exports.create = exports.destroy = exports.bulk = exports.query = exports.retrieve = exports.describe = void 0;
+exports.reference = exports.update = exports.upsertIf = exports.upsert = exports.createIf = exports.create = exports.destroy = exports.bulk = exports.directQuery = exports.query = exports.retrieve = exports.describe = void 0;
 
 var _languageCommon = require("@openfn/language-common");
 
@@ -301,6 +301,37 @@ const query = (0, _lodashFp.curry)(function (qs, state) {
   });
 });
 /**
+ * Execute an SOQL query and return result object.
+ * Note that in an event of a query error,
+ * error logs will be printed but the operation will not throw the error.
+ * @public
+ * @example
+ * directQuery(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);
+ * @constructor
+ * @param {String} qs - A query string.
+ * @param {State} state - Runtime state.
+ * @returns {Operation}
+ */
+
+exports.query = query;
+const directQuery = (0, _lodashFp.curry)(function (qs, state) {
+  let {
+    connection
+  } = state;
+  qs = (0, _languageCommon.expandReferences)(qs)(state);
+  console.log(`Executing query: ${qs}`);
+  return connection.query(qs, function (err, result) {
+    if (err) {
+      return console.error(err);
+    }
+
+    console.log('Results retrieved.');
+    return {
+      result
+    };
+  });
+});
+/**
  * Create and execute a bulk job.
  * @public
  * @example
@@ -318,7 +349,7 @@ const query = (0, _lodashFp.curry)(function (qs, state) {
  * @returns {Operation}
  */
 
-exports.query = query;
+exports.directQuery = directQuery;
 const bulk = (0, _lodashFp.curry)(function (sObject, operation, options, fun, state) {
   const {
     connection

--- a/src/Adaptor.js
+++ b/src/Adaptor.js
@@ -139,6 +139,38 @@ export const query = curry(function (qs, state) {
 });
 
 /**
+ * Execute an SOQL query and return result object.
+ * Note that in an event of a query error,
+ * error logs will be printed but the operation will not throw the error.
+ * @public
+ * @example
+ * directQuery(`SELECT Id FROM Patient__c WHERE Health_ID__c = '${state.data.field1}'`);
+ * @constructor
+ * @param {String} qs - A query string.
+ * @param {State} state - Runtime state.
+ * @returns {Operation}
+ */
+export const directQuery = curry(function (qs, state) {
+  let { connection } = state;
+  qs = expandReferences(qs)(state);
+  console.log(`Executing query: ${qs}`);
+
+  return connection.query(qs, function (err, result) {
+    if (err) {
+      return console.error(err);
+    }
+
+    console.log(
+      'Results retrieved.'
+    );
+
+    return {
+      result
+    };
+  });
+});
+
+/**
  * Create and execute a bulk job.
  * @public
  * @example


### PR DESCRIPTION
The current `query` function in `language-salesforce` adds the `result` object to the `state.references` array. For the bulk upsert, we need to be able to access and map the `result` object directly. 

The new `directQuery` function returns the `result` object directly, rather than adding in to `state.references`. 
Tested locally.

Please review the PR and leave any suggestion for tests, function name etc.

Thanks!